### PR TITLE
explicit cast of tribool to bool

### DIFF
--- a/edge.cpp
+++ b/edge.cpp
@@ -204,7 +204,7 @@ bool edge::is_on_boundary()
 	if(boost::logic::indeterminate(boundary))
 		boundary = (f == NULL) || (g == NULL);
 
-	return(boundary == true);
+	return(bool(boundary) == true);
 }
 
 /*!

--- a/face.cpp
+++ b/face.cpp
@@ -209,7 +209,7 @@ bool face::is_obtuse()
 		obtuse = (a*a+b*b < c*c) || (b*b* + c*c < a*a) || (c*c + a*a < b*b);
 	}
 
-	return(obtuse == true);
+	return(bool(obtuse) == true);
 }
 
 } // end of namespace "psalm"


### PR DESCRIPTION
fixes #1 
recent change in boost 1.69 needs explicit cast
https://www.boost.org/doc/libs/1_69_0/doc/html/boost/logic/tribool.html